### PR TITLE
Relax versions of LFE and ltest

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {lfe, "~> 2.1"},
-    {ltest, "~> 0.13.5"}
+    {lfe, "~> 2.1"}
 ]}.
 
 {plugins, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {lfe, "2.1.2"},
-    {ltest, "0.13.5"}
+    {lfe, "~> 2.1"},
+    {ltest, "~> 0.13.5"}
 ]}.
 
 {plugins, [

--- a/src/rebar3_lfe_prv_ltest.erl
+++ b/src/rebar3_lfe_prv_ltest.erl
@@ -34,7 +34,14 @@ init(State) ->
     {ok, State1}.
 
 do(State) ->
-    test(State).
+    case code:ensure_loaded(ltest) of
+        {module, ltest} ->
+            test(State);
+        _ ->
+            {error, "Could not find ltest. This typically means that you have "
+                    "not installed ltest as an explicit project depencency. Add "
+                    "{ltest, \"~> 0.13.5\"} to the deps section of your rebar.config."}
+    end.
 
 format_error({unknown_app, Unknown}) ->
     io_lib:format("Applications list for test contains an unrecognizable application definition: ~p", [Unknown]);


### PR DESCRIPTION
Right now a patch release must be made to this library every time there's a patch release of LFE. Relax that requirement so the latest patch and minor versions of LFE can be used.

Related to https://github.com/lfex/ltest/pull/75