### PR TITLE
Remove explicit depencency on ltest

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {lfe, "~> 2.1"},
-    {ltest, "~> 0.13.5"}
+    {lfe, "~> 2.1"}
 ]}.
 
 {plugins, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {lfe, "2.1.2"},
-    {ltest, "0.13.5"}
+    {lfe, "~> 2.1"},
+    {ltest, "~> 0.13.5"}
 ]}.
 
 {plugins, [

--- a/src/rebar3_lfe_prv_ltest.erl
+++ b/src/rebar3_lfe_prv_ltest.erl
@@ -34,7 +34,14 @@ init(State) ->
     {ok, State1}.
 
 do(State) ->
-    test(State).
+    case code:ensure_loaded(ltest) of
+        {module, ltest} ->
+            test(State);
+        _ ->
+            {error, "Could not find ltest. This typically means that you have "
+                    "not installed ltest as an explicit project depencency. Add "
+                    "{ltest, \"~> 0.13.5\"} to the deps section of your rebar.config."}
+    end.
 
 format_error({unknown_app, Unknown}) ->
     io_lib:format("Applications list for test contains an unrecognizable application definition: ~p", [Unknown]);


### PR DESCRIPTION
ltest is only used in this one particular provider, so it makes sense to me that we remove the explicit dependency on it and instead rely on the user of the plugin to list ltest in their dependencies. This is technically a breaking change, however the templates already list ltest as a separate dependency so I think that should be OK. I also added a warning with what to do if you don't have it installed. 

Supersedes #87 