### PR TITLE
added default compile to compile deps

### DIFF
--- a/src/rebar3_lfe_prv_compile.erl
+++ b/src/rebar3_lfe_prv_compile.erl
@@ -12,7 +12,7 @@
 
 -define(PROVIDER, compile).
 -define(NAMESPACE_PROVIDER, {?NAMESPACE, ?PROVIDER}).
--define(DEPS, [{default, lock}]).
+-define(DEPS, [{default, lock}, {default, compile}]).
 
 %% =============================================================================
 %% Plugin API
@@ -49,7 +49,7 @@ format_error(Reason) ->
 
 compile(State) ->
     rebar_api:debug("Compiling LFE apps ...", []),
-    rebar_paths:set_paths([deps], State), 
+    rebar_paths:set_paths([deps], State),
     Apps = rebar3_lfe_utils:get_apps(State),
     [compile_app(AppInfo, State) || AppInfo <- Apps],
     {ok, State}.


### PR DESCRIPTION
Adding `{default, compile}` will make that lfe compile will also trigger the default rebar3 compile. So if you have other providers it will compile that too.